### PR TITLE
fix: Remove unnecessary singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The statement about reliable internet connection is true when all these conditio
 
 ### ConnectionChecker init
 
-By instantiating the connecteo's `ConnectionChecker` class, you will always spawn a singleton. There are a couple of parameters (with its default values) that the constructor takes - you can modify them to suit your needs:
+There are a couple of parameters (with its default values) that the `ConnectionChecker`'s constructor takes - you can modify them to suit your needs:
 
 - checkHostReachability - let's you specify if you want to open a socket connection to the list of addresses (`checkAddresses`). Its default value is set to `true`.
 - checkAddresses - a list of custom `InternetAddress` which will be used to open the socket connections. The default list contains from three addresses: *CloudFlare (1.1.1.1)*, *Google (8.8.4.4)* and *OpenDNS (208.67.222.222)*.

--- a/lib/src/connection_checker.dart
+++ b/lib/src/connection_checker.dart
@@ -15,10 +15,10 @@ const _defaultFailureAttempts = 4;
 /// The class responsbile for checking and monitoring the actual internet
 /// connection by wrapping the [Connectivity] class and adding some extra checks.
 class ConnectionChecker {
-  /// Contructs a singleton of [ConnectionChecker] class.
+  /// Contructs an instance of [ConnectionChecker] class.
   ///
   /// The class comes with the list of optional parameters which you can
-  /// provide during singleton's init:
+  /// provide during init:
   ///
   /// - `checkHostReachabiltiy` - [bool] value which determines if
   /// [ConnectionChecker] should open a socket to a list of addresses.
@@ -61,7 +61,7 @@ class ConnectionChecker {
     Duration? requestInterval,
     int? failureAttempts,
   }) {
-    return _singleton ??= ConnectionChecker._(
+    return ConnectionChecker._(
       checkAddresses: checkAddresses,
       checkOverDnsTimeout: checkOverDnsTimeout,
       baseUrlLookupAddress: baseUrlLookupAddress,
@@ -118,8 +118,6 @@ class ConnectionChecker {
       requestInterval: requestInterval,
     );
   }
-
-  static ConnectionChecker? _singleton;
 
   final Connectivity _connectivity;
   final Mapper<ConnectivityResult, ConnectionType> _connectionTypeMapper;

--- a/test/connection_checker_test.dart
+++ b/test/connection_checker_test.dart
@@ -42,17 +42,6 @@ void main() {
     );
   });
 
-  group('init', () {
-    test('should return always the same ConnectionChecker instance (singleton)',
-        () {
-      final instance1 = ConnectionChecker();
-      final instance2 = ConnectionChecker();
-
-      expect(instance1 == instance2, true);
-      expect(instance1.hashCode == instance2.hashCode, true);
-    });
-  });
-
   group('isConnected', () {
     test(
         'returns false if hosts are not reachable although connection type is online',


### PR DESCRIPTION
_Problem_: if somebody wanted to change the parameters of `ConnectionChecker` after its instantiation, he wouldn't be able to do that because of the singleton with old parameters that is being returned.

_Solution_: replace the returning singleton with creating the `ConnectionChecker` instance on demand.