### PR TITLE
fix: map ConnectivityResult.other as connected

### DIFF
--- a/lib/src/connection_type.dart
+++ b/lib/src/connection_type.dart
@@ -6,8 +6,8 @@ enum ConnectionType {
   ethernet(true),
   mobile(true),
   vpn(true),
-  none(false),
-  unknown(false);
+  other(true),
+  none(false);
 
   // ignore: avoid_positional_boolean_parameters
   const ConnectionType(this.onlineType);

--- a/lib/src/connection_type_mapper.dart
+++ b/lib/src/connection_type_mapper.dart
@@ -20,10 +20,10 @@ class ConnectionTypeMapper
         return ConnectionType.vpn;
       case ConnectivityResult.wifi:
         return ConnectionType.wifi;
+      case ConnectivityResult.other:
+        return ConnectionType.other;
       case ConnectivityResult.none:
         return ConnectionType.none;
-      case ConnectivityResult.other:
-        return ConnectionType.unknown;
     }
   }
 }


### PR DESCRIPTION
The [README](https://pub.dev/packages/connectivity_plus#usage) of connectivity_plus says that `ConnectivityResult.other` means that the device has connection to internet, but the source is unknown.

In this PR I map `ConnectivityResult.other` to new status `ConnectionType.other` which informs that device is online