### PR TITLE
chore: update connectivity plus dependency to newest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install environment
         uses: subosito/flutter-action@v2.8.0
         with:
-          flutter-version: 3.3.10
+          flutter-version: 3.7.0
 
       - name: Get dependencies
         run: flutter pub get
@@ -23,7 +23,7 @@ jobs:
         run: flutter analyze
 
       - name: Check format
-        run: flutter format --fix --set-exit-if-changed .
+        run: dart format --fix --set-exit-if-changed .
         
       - name: Run the tests
         run: flutter test

--- a/lib/connecteo.dart
+++ b/lib/connecteo.dart
@@ -1,3 +1,5 @@
+/// Connecteo is a library that allows you to check the internet connection
+/// and track changes in the connection status.
 library connecteo;
 
 export 'src/connection_checker.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,11 @@ homepage: https://github.com/Iteo/connecteo
 documentation: https://github.com/Iteo/connecteo/blob/master/README.md
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
-  flutter: ">=3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
+  flutter: ">=3.7.0"
 
 dependencies:
-  connectivity_plus: ^3.0.5
+  connectivity_plus: ^4.0.1
   flutter:
     sdk: flutter
   rxdart: ^0.27.7


### PR DESCRIPTION
Updated connectivity plus to new major version. Starting with connectivity_plus 4.0.0 the minimum flutter version required is 3.3.0 and Android Gradle Plugin needs to be at least at version 7.0 to avoid problems, also the minimum android version required has been changed to 4.4 and iOS to 11, so if we were to introduce this package bump we maybe should bump major version as it is introducing breaking changes (similar to what connectivity_plus has done)?